### PR TITLE
Issue #3329318: Drupal 10 compatibility fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     ],
     "require": {
         "php": "^7.1 || ^8.0",
-        "psr/log": "^1.0",
-        "guzzlehttp/guzzle": "^6.3"
+        "psr/log": "^1.0 || ^3.0",
+        "guzzlehttp/guzzle": "^6.3 || ^7.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^2.7",


### PR DESCRIPTION
The current Composer package isn't able to use on Drupal 10 implementations.

Some Drupal community members opened the https://www.drupal.org/project/janrain_connect/issues/3329318 issue, reporting this compatibility issue and brought some fixes. These code modifications were brought by these members.

Please, update this package to cover the new Drupal's version.