### PR TITLE
Add entity.create endpoint

### DIFF
--- a/src/JanrainRest.php
+++ b/src/JanrainRest.php
@@ -696,6 +696,29 @@ class JanrainRest
     }
 
     /**
+     * Creates an entity.
+     *
+     * @param string $attributes Attribute and values to be created.
+     * @param string $typeName The name of the entityType.
+     * @param string $clientId The client id.
+     * @param string $clientSecret The client secret.
+     *
+     * @return array
+     */
+    public function entityCreate(string $attributes = '', string $typeName = '', $clientId = FALSE, $clientSecret = FALSE)
+    {
+        $idpResponse = $this->entityInstance->entityCreate($attributes, $typeName, $clientId, $clientSecret);
+
+        if ($idpResponse->stat == 'ok') {
+            return [
+                'has_errors' => false,
+            ];
+        }
+
+        return $this->returnErrors($idpResponse);
+    }
+
+    /**
      * Get flow versions.
      *
      * @return array

--- a/src/core/Entity.php
+++ b/src/core/Entity.php
@@ -88,6 +88,61 @@ class Entity
     }
 
     /**
+     * Create a new entity with the provided data.
+     * This data is provided in a JSON object that specifies the path to the attribute, and the value to use.
+     *
+     * Public documentation: https://techdocs.akamai.com/identity-cloud-entity/reference/post-entity-create
+     *
+     * Service path: /entity.create
+     *
+     * Response example:
+     * {
+     *      "stat": "ok",
+     * }
+     *
+     * @param string $attributes Attribute and values to be created.
+     * @param string $typeName The name of the entityType.
+     * @param string $clientId The client id.
+     * @param string $clientSecret The client secret.
+     *
+     * @return mixed
+     */
+    public function entityCreate($attributes = FALSE, string $typeName = '', $clientId = FALSE, $clientSecret = FALSE)
+    {
+      $captureServerUrl = $this->baseCoreInstance->captureServerUrl;
+      $serviceUrl = '/entity.create';
+
+      $data = [];
+
+      if (!empty($typeName)) {
+        $data['type_name'] = $typeName;
+      }
+
+      if (!empty($attributes)) {
+        $data['attributes'] = $attributes;
+      }
+
+      $method = 'post';
+
+      if (empty($clientId)) {
+        $clientId = $this->baseCoreInstance->fullClientId;
+      }
+
+      if (empty($clientSecret)) {
+        $clientSecret = $this->baseCoreInstance->fullClientSecret;
+      }
+
+      return $this->baseCoreInstance->requestInstance->request(
+        $captureServerUrl,
+        $serviceUrl,
+        $data,
+        $method,
+        $clientId,
+        $clientSecret
+      );
+    }
+
+    /**
      * Delete a single entity (and any nested objects) from an application, or delete an element of a plural.
      *
      * Public documentation: https://docs.janrain.com/api/registration/entity/#entity-delete
@@ -272,7 +327,7 @@ class Entity
         if (!empty($attributes)) {
           $data['attributes'] = $attributes;
         }
-    
+
         if (!empty($uuid)) {
           $data['uuid'] = $uuid;
         }

--- a/src/tests/JanrainTest.php
+++ b/src/tests/JanrainTest.php
@@ -258,6 +258,20 @@ class JanrainTest extends TestCase
     }
 
     /**
+     * @covers Janrain\Janrain::entityUpdate
+     * @depends testRegisterNativeTraditional
+     */
+    public function testEntityCreate()
+    {
+        $typeName   = $this->baseTest->typeName;
+        $attributes = json_encode($this->baseTest->getEntityUpdateMock());
+
+        $json = $this->janrain->entityCreate($$attributes, $typeName);
+
+        $this->assertNotTrue($json['has_errors']);
+    }
+
+    /**
      * @covers Janrain\Janrain::entityDeleteAccess
      * @depends testRegisterNativeTraditional
      */

--- a/src/tests/JanrainTest.php
+++ b/src/tests/JanrainTest.php
@@ -258,15 +258,16 @@ class JanrainTest extends TestCase
     }
 
     /**
-     * @covers Janrain\Janrain::entityUpdate
+     * @covers Janrain\Janrain::entityCreate
      * @depends testRegisterNativeTraditional
      */
     public function testEntityCreate()
     {
         $typeName   = $this->baseTest->typeName;
+        // We can use the same mock entityUpdate uses.
         $attributes = json_encode($this->baseTest->getEntityUpdateMock());
 
-        $json = $this->janrain->entityCreate($$attributes, $typeName);
+        $json = $this->janrain->entityCreate($attributes, $typeName);
 
         $this->assertNotTrue($json['has_errors']);
     }


### PR DESCRIPTION
This project misses the [/entity.create](https://techdocs.akamai.com/identity-cloud-entity/reference/post-entity-create) endpoint method. This PR should add this new method.

Even though I've tested these changes on our codebase, I will keep this PR marked as a draft until the automated tests are executed.